### PR TITLE
Fix template tag error

### DIFF
--- a/includes/template-hierarchy.php
+++ b/includes/template-hierarchy.php
@@ -93,8 +93,8 @@ function maera_templates_hierarchy( $templates = array() ) {
  	// Tag templates
  	if ( is_tag() ) {
 
-		$tag = get_tag( get_query_var( 'tag' ) );
-		$tag_id = get_query_var( 'tag_id' );
+		$tag = get_term_by( 'slug', get_query_var( 'tag' ), 'post_tag' );
+		$tag_id = $tag->term_id;
 		$tag_slug = $tag->slug;
 
 		$templates[] = 'tag-' . $tag_slug . '.twig';


### PR DESCRIPTION
If you change the WP_DEBUG to true in wp-config.php you end up getting an error when accessing the URL of a tag:

Notice: Trying to get property of non-object in /path/to/site/wp-content/themes/maera/includes/template-hierarchy.php on line 100

This pull request corrects this behavior.
